### PR TITLE
Remove stray SHM files in fallback mode

### DIFF
--- a/preload/src/lib.rs
+++ b/preload/src/lib.rs
@@ -3,7 +3,7 @@ use std::os::fd::IntoRawFd;
 
 #[no_mangle]
 pub extern "C" fn xshmfence_alloc_shm() -> c_int {
-    match util::create_shm_file() {
+    match util::create_shm_file(true) {
         Ok((_, file)) => file.into_raw_fd(),
         Err(_) => -1,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::{c_long, CString};
-use std::fs::{read_to_string, File};
+use std::fs::{read_to_string, remove_file, File};
 use std::io::{IoSlice, IoSliceMut, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::num::NonZeroUsize;
@@ -1170,7 +1170,7 @@ impl Client {
             shmem_file = File::from(memfd);
         } else {
             let shmem_name;
-            (shmem_name, shmem_file) = util::create_shm_file()?;
+            (shmem_name, shmem_file) = util::create_shm_file(false)?;
             let mut shmem_path = util::SHM_PREFIX.to_owned();
             for c in shmem_name {
                 shmem_path.push(c as char);
@@ -1179,6 +1179,7 @@ impl Client {
             read(memfd.as_raw_fd(), &mut data)?;
             shmem_file.write_all(&data)?;
             Self::replace_futex_storage(memfd.as_raw_fd(), Pid::from_raw(pid), &shmem_path)?;
+            remove_file(&shmem_path)?;
         }
 
         let mut handle: ExportedHandle = Default::default();

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use std::fs::File;
+use std::fs::{remove_file, File};
 use std::io::ErrorKind;
 
 pub const SHM_PREFIX: &'static str = "/dev/shm/krshm-";
@@ -7,7 +7,7 @@ pub const SHM_DIR: &'static str = "/dev/shm/";
 
 pub type Result<T> = std::result::Result<T, std::io::Error>;
 
-pub fn create_shm_file() -> Result<([u8; 8], File)> {
+pub fn create_shm_file(remove: bool) -> Result<([u8; 8], File)> {
     let mut rng = rand::thread_rng();
     loop {
         let shmem_name = [0x30u8; 8].map(|x| x + rng.gen_range(0..10));
@@ -22,6 +22,9 @@ pub fn create_shm_file() -> Result<([u8; 8], File)> {
             .open(&shmem_path);
         match result {
             Ok(file) => {
+                if remove {
+                    remove_file(&shmem_path)?;
+                }
                 file.set_len(4)?;
                 return Ok((shmem_name, file));
             }


### PR DESCRIPTION
We don't use these paths in the host any more, so just remove the file. For the preload, this is done immediately. For the ptrace fallback, after replacing the futex storage.